### PR TITLE
feat: replace hardcoded email with env variable

### DIFF
--- a/config/statamic-safeguard.php
+++ b/config/statamic-safeguard.php
@@ -12,7 +12,7 @@ return [
      * Be aware that allowing supers, will bypass protection
      * which can lead to breaking changes in production!
      */
-    'super' => ['syda@tv2reg.dk'],
+    'super' => explode(',', env('STATAMIC_SAFEGUARD_SUPER_EMAILS', '')),
 
     /**
      * An array of permissions to disallow.


### PR DESCRIPTION
This pull request updates the configuration for Statamic Safeguard to improve flexibility and security by using environment variables for specifying super user emails.

Configuration update:

* [`config/statamic-safeguard.php`](diffhunk://#diff-7444a92a355a1554fae27ddc065e47ea10edd40e91090dd9c5b3a759068c8482L15-R15): Changed the `super` setting to dynamically retrieve super user emails from the `STATAMIC_SAFEGUARD_SUPER_EMAILS` environment variable using `explode()`. This allows easier management and avoids hardcoding sensitive information.